### PR TITLE
Fixes Behavior in Windows Agent. Closes #8

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ function getFiles(): string[] {
     core.getInput("files", {
       required: true
     }) || "";
+  files = files.replace("\\","\\\\");
   if (files.trim().startsWith("[")) {
     return JSON.parse(files);
   }


### PR DESCRIPTION
This PR fixes the following issue on running this Action on Windows Agents:

` Unexpected token a in JSON at position 5`

This is caused by `JSON.parse` not being able to parse the `\` character which is used in Windows paths.

To solve this, we need to escape the `\`, so I did add that line to this PR

This PR closes #8 