### PR TITLE
Fix build error

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,11 @@ async function run() {
     );
     console.log(`Replaced tokens in files: ${result}`);
   } catch (error) {
-    core.setFailed(error.message);
+    if (error instanceof Error) {
+      core.setFailed(error.message);
+    } else {
+      core.setFailed(String(error));
+    }
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,11 +26,7 @@ async function run() {
     );
     console.log(`Replaced tokens in files: ${result}`);
   } catch (error) {
-    if (error instanceof Error) {
-      core.setFailed(error.message);
-    } else {
-      core.setFailed(String(error));
-    }
+    if (error instanceof Error) core.setFailed(error.message);
   }
 }
 


### PR DESCRIPTION
This PR fixes a previously introduced build error where the catch clauses `error` would fail the build, since it was not typed. My bad 😬 

https://github.com/actions/typescript-action/blob/6275f884bd7f89a8e4eaae00edec4bdaea62c51b/src/main.ts#L15